### PR TITLE
Modify CHANGELOG.md & README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: csharp
-solution: FlexberryGisTestStand.sln
+solution: Docker/gis-test-stand-odata/sources/FlexberryGisTestStand.sln

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.1.0] 23-05-2019
 ### Added
 - /flexberry/gis-test-stand-geoserver:1.1.0 image
-- postges initial data
+- postgres initial data
 - autobuilding all images
 
 ### Fixed
 
 ### Changed
-- Git-tagging of images changes from 1.1.0-postgresql-db, to flexberry/gis-test-stand-postgres-db_1.1.0
+- Git-tagging of images changes from 1.1.0-postgresql-db, to gis-test-stand-postgres-db_1.1.0
 - Image flexberry/gis-test-stand rename to flexberry/gis-test-stand-odata;
 - Optimize Files structure (move /SQL to Docker/gis-test-stand-postgres-db/host, source of odata to Docker/gis-test-stand-odata);
 - Optimize Dockerfiles;
+- Remove hooks/build, hooks/post_push, add hooks/pre_push, hooks/post_push for all images
+- Add Docker/hookFunctions.sh
 - Change version of images in docker-compose.yml from  latest to 1.1
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.1.0] 23-05-2019
 ### Added
+- /flexberry/gis-test-stand-geoserver:1.1.0 image
+- postges initial data
+- autobuilding all images
 
 ### Fixed
 
 ### Changed
+- Git-tagging of images changes from 1.1.0-postgresql-db, to flexberry/gis-test-stand-postgres-db_1.1.0
+- Image flexberry/gis-test-stand rename to flexberry/gis-test-stand-odata;
+- Optimize Files structure (move /SQL to Docker/gis-test-stand-postgres-db/host, source of odata to Docker/gis-test-stand-odata);
+- Optimize Dockerfiles;
+- Change version of images in docker-compose.yml from  latest to 1.1
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Git-tagging of images changes from 1.1.0-postgresql-db, to gis-test-stand-postgres-db_1.1.0
 - Image flexberry/gis-test-stand rename to flexberry/gis-test-stand-odata;
-- Optimize Files structure (move /SQL to Docker/gis-test-stand-postgres-db/host, source of odata to Docker/gis-test-stand-odata);
-- Optimize Dockerfiles;
+- Optimize Files structure (move /SQL to Docker/gis-test-stand-postgres-db/host, source of odata to Docker/gis-test-stand-odata/source);
+- Optimize Dockerfiles, remove git clone ..., wget ... from native repository;
 - Remove hooks/build, hooks/post_push, add hooks/pre_push, hooks/post_push for all images
 - Add Docker/hookFunctions.sh
-- Change version of images in docker-compose.yml from  latest to 1.1
+- Change version of images in yml-files from  latest to 1.1
 
 

--- a/Docker/gis-test-stand-swarm-configuration-debug.yml
+++ b/Docker/gis-test-stand-swarm-configuration-debug.yml
@@ -1,16 +1,21 @@
 version: '3'
 services:
   GisTestStandPostgres:
-    image: "flexberry/gis-test-stand-postgres-db:latest"
+    image: "flexberry/gis-test-stand-postgres-db:1.1"
     volumes:
       - GisTestStandDB:/var/lib/pgsql/data/
     ports:
      - "5432:5432"
   GisTestStand:
-    image: "flexberry/gis-test-stand:latest"
+    image: "flexberry/gis-test-stand-odata:1.1"
     command: /bin/sleep 11d
     ports:
      - "1818:80"
+  GisTestStandGeoserver:
+    image: "flexberry/gis-test-stand-geoserver:1.1"
+    port:
+     - "1819:8080"
+
 
 volumes:
   GisTestStandDB: 

--- a/Docker/gis-test-stand-swarm-configuration.yml
+++ b/Docker/gis-test-stand-swarm-configuration.yml
@@ -1,15 +1,15 @@
 version: '3'
 services:
   GisTestStandPostgres:
-    image: "flexberry/gis-test-stand-postgres-db:latest"
+    image: "flexberry/gis-test-stand-postgres-db:1.1"
     volumes:
       - GisTestStandDB:/var/lib/pgsql/data/
   GisTestStand:
-    image: "flexberry/gis-test-stand:latest"
+    image: "flexberry/gis-test-stand-odata:1.1"
     ports:
      - "1818:80"
   GisTestStandGeoserver:
-    image: "flexberry/gis-test-stand-geoserver:latest"
+    image: "flexberry/gis-test-stand-geoserver:1.1"
     port:
      - "1819:8080"
 

--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ OData backed for flexberry-gis-test-stand-ember-frontend
 ## Docker images
 
 * PostgreSQL Database: [flexberry/gis-test-stand-postgres-db](https://hub.docker.com/r/flexberry/gis-test-stand-postgres-db/)
-* Web Application: [flexberry/gis-test-stand](https://hub.docker.com/r/flexberry/gis-test-stand/)
+* Web Application: [flexberry/gis-test-stand-odata](https://hub.docker.com/r/flexberry/gis-test-stand-data/)
+* Geoserver Application [https://hub.docker.com/r/flexberry/gis-test-stand-geoserver](https://hub.docker.com/r/https://hub.docker.com/r/flexberry/gis-test-stand-geoserver)


### PR DESCRIPTION
## [1.1.0] 23-05-2019
### Added
- /flexberry/gis-test-stand-geoserver:1.1.0 image
- postges initial data
- autobuilding all images

### Fixed

### Changed
- Git-tagging of images changes from 1.1.0-postgresql-db, to flexberry/gis-test-stand-postgres-db_1.1.0
- Image flexberry/gis-test-stand rename to flexberry/gis-test-stand-odata;
- Optimize Files structure (move /SQL to Docker/gis-test-stand-postgres-db/host, source of odata to Docker/gis-test-stand-odata);
- Optimize Dockerfiles;
- Change version of images in docker-compose.yml from  latest to 1.1


